### PR TITLE
build: update docker backend base to go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
the [go.mod](https://github.com/whyrusleeping/konbini/blob/a7c3b33c632ec0d029510c3233ccf406d12eca2c/go.mod#L3C4-L3C10) file declares the minimum go version as 1.25 but the docker image was using 1.21 leading to build failures.