### PR TITLE
Misc docker changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
     container_name: konbini-backend
     environment:
       - DATABASE_URL=postgres://konbini:konbini_password@postgres:5432/konbini?sslmode=disable
-      - BSKY_HANDLE=${BSKY_HANDLE}
-      - BSKY_PASSWORD=${BSKY_PASSWORD}
+      - BSKY_HANDLE=${BSKY_HANDLE:?}
+      - BSKY_PASSWORD=${BSKY_PASSWORD:?}
     ports:
       - "4444:4444"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
- Update frontend to use node:24 (lts) over deprecated node:18 (builds currently output warnings due to using it)
- Make the compose file refuse to start when the required environment variables are unset instead of defaulting to empty strings
- Remove the `version` attribute from the compose file to remove deprecation warning

Have tested all these locally